### PR TITLE
Fix encoding when importing recipies

### DIFF
--- a/lib/utilities/utils.dart
+++ b/lib/utilities/utils.dart
@@ -19,11 +19,10 @@ class Utils {
     File file = File(filePath);
 
     DatabaseService db = DatabaseService();
-    db.export().then((String result) {
-      var fileBytes = _textFileEncoding.encode(result);
-      file.writeAsBytes(fileBytes);
-      Share.shareXFiles([XFile(filePath)]);
-    });
+    String result = await db.export();
+    var fileBytes = _textFileEncoding.encode(result);
+    await file.writeAsBytes(fileBytes);
+    await Share.shareXFiles([XFile(filePath)]);
   }
 
   static Future<int> userImport() async {
@@ -38,7 +37,7 @@ class Utils {
       var fileBytes = await file.readAsBytes();
       String backupContent = _textFileEncoding.decode(fileBytes);
       DatabaseService db = DatabaseService();
-      db.import(backupContent);
+      await db.import(backupContent);
     }
     return 1;
   }

--- a/lib/utilities/utils.dart
+++ b/lib/utilities/utils.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
@@ -8,6 +9,8 @@ import 'package:reciper/utilities/database.dart';
 import 'package:share_plus/share_plus.dart';
 
 class Utils {
+  static const Encoding _textFileEncoding = utf8;
+
   static Future<void> userExport() async {
     Directory directory = await getTemporaryDirectory();
     String appDocumentsPath = directory.path;
@@ -17,7 +20,8 @@ class Utils {
 
     DatabaseService db = DatabaseService();
     db.export().then((String result) {
-      file.writeAsString(result);
+      var fileBytes = _textFileEncoding.encode(result);
+      file.writeAsBytes(fileBytes);
       Share.shareXFiles([XFile(filePath)]);
     });
   }
@@ -31,7 +35,8 @@ class Utils {
         await openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
 
     if (file != null) {
-      String backupContent = await file.readAsString();
+      var fileBytes = await file.readAsBytes();
+      String backupContent = _textFileEncoding.decode(fileBytes);
       DatabaseService db = DatabaseService();
       db.import(backupContent);
     }


### PR DESCRIPTION
### Summary

Fix to import functionality when importing recipies that contain "special" characters.

### Changes

- Use `XFile.readAsBytes()` and `Encoding.decode(...)` instead of `XFile.readAsString()` in function **userImport** of class **Utils**
  - I have no previous experience with Dart so I have no idea why `XFile.readAsString()` didn't work :sweat_smile:
- Change file writing code in function **userExport** of class **Utils** so that it uses `Encoding.encode(...)` and `File.writeAsBytes()` (this change is just for consistency)
- Added some missing(?) `await` keywords to the import and export functions
  - The file export would sometimes just export an empty file, so that might have been an issue with the async code. Not sure. :thinking: Again, this is my first time using Dart so I might be wrong

### Detailed problem description

Encoding seemed to break when recipies with certain special characters were imported (e.g. characters that are used in other languages besides English). Steps to reproduce:

1. Create a new recipe
2. Add with some non-English characters (like åäö) to one or all of the text fields
   - Or copy-paste the test data at the end of this PR description)
4. Save the recipe
5. Go to "Settings" -> "Export recipies" and export the data (e.g. to Google Drive)
6. Go to "Home" and delete the test recipe
7. Go to "Settings" -> "Import recipies" and import the file that was exported in step 4
8. Go to "Home" and view the recipe => the non-English characters are not the same

---

I created a test recipe to demonstrate the issue:

<details>
<summary>Initial test recipe (image)</summary>

![reciper-initial-encoding-test](https://github.com/judemont/reciper/assets/9085952/4cdaa299-2fe3-4ef6-b3aa-47d4747a5d92)

</details>

When recipies were exported (e.g. to Google Drive), deleted from Reciper and imported back, this was the result:

<details>
<summary>Imported broken recipe (image)</summary>

![reciper-broken-import-encoding](https://github.com/judemont/reciper/assets/9085952/f12f979c-e59a-49b2-8799-f6fbbbb53f63)

</details>

I viewed the exported json file and its contents were fine:
```json
[["Recipes"],[[{"id":27,"steps":"-","title":"Encoding test","servings":"1","ingredients":"Numbers: 123\nLower case characters: abc\nUpper case characters: ABC\n\nLower case DK/FI/NO/SE characters: åäöæø\nUpper case DK/FI/NO/SE letters: ÅÄÖÆØ\n\nLower case IS characters: áðéíóúýþ\nUpper case IS characters: ÁÐÉÍÓÚÝÞ\n\nLower case DE characters: ßü\nUpper case DE characters: ẞÜ\n\nLower case FR characters: àâçèêëîïôœùûÿ\nUpper case FR characters: ÀÂÇÈÊËÎÏÔŒÙÛŸ\n\nRandom emojis: 😊🤣😎🍕🍔🥗🍝\n\nRandom kaomojis: (●'◡'●) ᓚᘏᗢ (╯°□°）╯︵ ┻━┻","source":""}]]]
```

Here's the text for the recipe that I used to initially create the recipe in the UI (can be just copy-pasted into the **Ingredients** field):

<details>
<summary>Data for creating the test recipe</summary>

```
Numbers: 123
Lower case characters: abc
Upper case characters: ABC

Lower case DK/FI/NO/SE characters: åäöæø
Upper case DK/FI/NO/SE letters: ÅÄÖÆØ

Lower case IS characters: áðéíóúýþ
Upper case IS characters: ÁÐÉÍÓÚÝÞ

Lower case DE characters: ßü
Upper case DE characters: ẞÜ

Lower case FR characters: àâçèêëîïôœùûÿ
Upper case FR characters: ÀÂÇÈÊËÎÏÔŒÙÛŸ

Random emojis:
😊🤣😎🍕🍔🥗🍝

Random kaomojis:
(●'◡'●)
ᓚᘏᗢ
(╯°□°）╯︵ ┻━┻
```

</details>

---

Feel free to ask questions or request changes!