### PR TITLE
fix: correct GitHub language stats to reflect Dart codebase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Ensure all Dart files are detected as Dart
+*.dart linguist-language=Dart
+
+# Exclude generated Flutter build outputs
+build/** linguist-generated
+**/flutter_assets/** linguist-generated
+**/app.so linguist-generated
+**/libs.jar linguist-generated
+**/flutter_build.d linguist-generated
+**/NOTICES.Z linguist-generated
+
+# Exclude generated Fastlane metadata and images
+fastlane/metadata/** linguist-generated
+*.png linguist-generated
+*.js linguist-generated
+
+# Exclude Android build intermediates
+android/app/build/** linguist-generated
+android/gradle/** linguist-generated

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # 🍳 Reciper - Your Ultimate Kitchen Companion! 📱
 
 ---
-> If anyone knows why tf Github thinks Reciper is in MakeFile when there are infinitely more Dart, please tell me.
----
----
 <a href='https://apt.izzysoft.de/fdroid/index/apk/jdm.apps.reciper/'>
   <center><img src="https://github.com/judemont/reciper/assets/96385330/9ee04ade-5eef-4a74-953a-5d075c3bb419" width="170"></center>
 </a>


### PR DESCRIPTION
GitHub reporting this project as mostly Makefile (~73%) was due to large generated binaries and Flutter build artifacts.

This PR adds a .gitattributes file to:
- Force Dart files to be recognized as Dart
- Exclude build outputs like app.so, libs.jar, flutter_assets, and Fastlane metadata
- Ignore large non-source assets such as PNGs and JS helper files

These changes should result in the project language being showed as ~90% Dart
